### PR TITLE
Handle redis errors on queues view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ requirements:
 	pip install -r requirements-dev.txt
 
 test:
-	pytest
+	python -m pytest
 
 coverage-collect:
 	coverage run -m pytest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ requirements:
 	pip install -r requirements-dev.txt
 
 test:
-	python -m pytest
+	pytest
 
 coverage-collect:
 	coverage run -m pytest

--- a/arq_admin/templates/arq_admin/queues.html
+++ b/arq_admin/templates/arq_admin/queues.html
@@ -3,67 +3,88 @@
 {% block title %}Queues {{ block.super }}{% endblock %}
 
 {% block extrastyle %}
-    {{ block.super }}
-    <style>table {width: 100%;}</style>
+  {{ block.super }}
+  <style>
+      table {
+          width: 100%;
+      }
+  </style>
 {% endblock %}
 
 {% block content_title %}<h1>ARQ Queues</h1>{% endblock %}
 
 {% block breadcrumbs %}
-    <div class="breadcrumbs">
-        <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'arq_admin:home' %}">Django ARQ</a>
-    </div>
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
+    <a href="{% url 'arq_admin:home' %}">Django ARQ</a>
+  </div>
 {% endblock %}
 
 {% block content %}
 
-<div id="content-main">
+  <div id="content-main">
 
     <div class="module">
-        <table>
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Queued Jobs</th>
-                    <th>Deferred Jobs</th>
-                    <th>Running Jobs</th>
-                    <th>Host</th>
-                    <th>Port</th>
-                    <th>DB</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for queue in object_list %}
-                    <tr class = "{% cycle 'row1' 'row2' %}">
-                        <th>
-                            <a href="{% url 'arq_admin:all_jobs' queue.name %}">
-                                {{ queue.name }}
-                            </a>
-                        </th>
-                        <td>
-                            <a href="{% url 'arq_admin:queued_jobs' queue.name %}">
-                                {{ queue.queued_jobs }}
-                            </a>
-                        </td>
-                        <th>
-                            <a href="{% url 'arq_admin:deferred_jobs' queue.name %}">
-                                {{ queue.deferred_jobs }}
-                            </a>
-                        </th>
-                        <th>
-                              <a href="{% url 'arq_admin:running_jobs' queue.name %}">
-                                  {{ queue.running_jobs }}
-                              </a>
-                        </th>
-                        <td>{{ queue.host }}</td>
-                        <td>{{ queue.port }}</td>
-                        <td>{{ queue.database }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+      {% for queue in object_list %}
+        {% if queue.error %}
+          <h2>{{ queue.name }} - <span style="color: red;">{{ queue.error }}</span></h2>
+        {% endif %}
+      {% endfor %}
+      <table>
+        <thead>
+        <tr>
+          <th>Name</th>
+          <th>Queued Jobs</th>
+          <th>Deferred Jobs</th>
+          <th>Running Jobs</th>
+          <th>Host</th>
+          <th>Port</th>
+          <th>DB</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for queue in object_list %}
+          <tr class="{% cycle 'row1' 'row2' %}">
+            <th>
+              <a href="{% url 'arq_admin:all_jobs' queue.name %}">
+                {{ queue.name }}
+              </a>
+            </th>
+            <td>
+              {% if queue.queued_jobs is None %}
+                —
+              {% else %}
+                <a href="{% url 'arq_admin:queued_jobs' queue.name %}">
+                  {{ queue.queued_jobs }}
+                </a>
+              {% endif %}
+            </td>
+            <th>
+              {% if queue.deferred_jobs is None %}
+                —
+              {% else %}
+                <a href="{% url 'arq_admin:deferred_jobs' queue.name %}">
+                  {{ queue.deferred_jobs }}
+                </a>
+              {% endif %}
+            </th>
+            <th>
+              {% if queue.running_jobs is None %}
+                —
+              {% else %}
+                <a href="{% url 'arq_admin:running_jobs' queue.name %}">
+                  {{ queue.running_jobs }}
+                </a>
+              {% endif %}
+            </th>
+            <td>{{ queue.host }}</td>
+            <td>{{ queue.port }}</td>
+            <td>{{ queue.database }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
     </div>
-</div>
+  </div>
 
 {% endblock %}

--- a/arq_admin/views.py
+++ b/arq_admin/views.py
@@ -18,18 +18,21 @@ class QueueListView(ListView):
     template_name = 'arq_admin/queues.html'
 
     def get_queryset(self) -> List[QueueStats]:
-        async def _gather_queues() -> List[QueueStats]:
-            tasks = [Queue.from_name(name).get_stats() for name in ARQ_QUEUES.keys()]
 
-            return await asyncio.gather(*tasks)
-
-        return asyncio.run(_gather_queues())
+        result = asyncio.run(self._gather_queues())
+        return result
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context.update(admin.site.each_context(self.request))
 
         return context
+
+    @staticmethod
+    async def _gather_queues() -> List[QueueStats]:
+        tasks = [Queue.from_name(name).get_stats() for name in ARQ_QUEUES.keys()]
+
+        return await asyncio.gather(*tasks)
 
 
 @method_decorator(staff_member_required, name='dispatch')

--- a/arq_admin/views.py
+++ b/arq_admin/views.py
@@ -30,7 +30,7 @@ class QueueListView(ListView):
 
     @staticmethod
     async def _gather_queues() -> List[QueueStats]:
-        tasks = [Queue.from_name(name).get_stats() for name in ARQ_QUEUES.keys()]
+        tasks = [Queue.from_name(name).get_stats() for name in ARQ_QUEUES.keys()]  # pragma: nocover
 
         return await asyncio.gather(*tasks)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,10 +68,10 @@ filterwarnings =
   ignore::UserWarning:pytest.*:
   ignore::ResourceWarning:redis.*:
 junit_family = xunit1
-;addopts =
-;    --cov=arq_admin
-;    --cov-fail-under 100
-;    --cov-report term-missing
+addopts =
+    --cov=arq_admin
+    --cov-fail-under 100
+    --cov-report term-missing
 
 [coverage:run]
 source = arq_admin

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from arq.constants import default_queue_name
@@ -39,6 +39,21 @@ async def test_stats() -> None:
         queued_jobs=1,
         running_jobs=1,
         deferred_jobs=1,
+    )
+
+
+@pytest.mark.asyncio()
+@patch.object(Queue, '_get_job_ids')
+async def test_stats_with_error(mocked_get_job_ids: AsyncMock) -> None:
+    error_text = 'test error'
+    mocked_get_job_ids.side_effect = Exception(error_text)
+    queue = Queue.from_name(default_queue_name)
+    assert await queue.get_stats() == QueueStats(
+        name=default_queue_name,
+        host=settings.REDIS_SETTINGS.host,
+        port=settings.REDIS_SETTINGS.port,
+        database=settings.REDIS_SETTINGS.database,
+        error=error_text,
     )
 
 


### PR DESCRIPTION
Sometimes it's not possible to fetch data from one of the queues. It may be caused by misconfigured queue, network issues, or redis issues. 
In this case we still want to show all jobs, but we need to make sure we let know about the error to the user