### PR TITLE
Use a regex instead of split by colon when parsing arq keys

### DIFF
--- a/arq_admin/queue.py
+++ b/arq_admin/queue.py
@@ -155,10 +155,11 @@ class Queue:
             await pipe.zrange(self.name, withscores=True, start=0, end=-1)
             all_arq_keys, job_ids_with_scores = await pipe.execute()
 
+        regex_matches_from_arq_keys = (ARQ_KEY_REGEX.match(key.decode('utf-8')) for key in all_arq_keys)
         # iter over dicts with job ids and their keys' prefixes
         # can't create mapping from ids to prefixes right away here
         # because we can have multiple keys with different prefixes for one job and need to use the more specific one
-        job_ids_with_prefixes = (ARQ_KEY_REGEX.match(key.decode('utf-8')).groupdict() for key in all_arq_keys)
+        job_ids_with_prefixes = (match.groupdict() for match in regex_matches_from_arq_keys if match is not None)
 
         job_ids_to_scores = {key[0].decode('utf-8'): key[1] for key in job_ids_with_scores}
         job_ids_to_prefixes = dict(sorted(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -68,7 +68,7 @@ async def test_stats_with_running_job_wo_zscore(redis: ArqRedis, queue: Queue) -
 @pytest.mark.asyncio()
 @pytest.mark.usefixtures('all_jobs')
 async def test_stats_job_with_colon_in_the_name(redis: ArqRedis, queue: Queue) -> None:
-    job = await redis.enqueue_job('new_task', _job_id='queued:task')
+    await redis.enqueue_job('new_task', _job_id='queued:task')
 
     assert await queue.get_stats() == QueueStats(
         name=default_queue_name,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -66,6 +66,22 @@ async def test_stats_with_running_job_wo_zscore(redis: ArqRedis, queue: Queue) -
 
 
 @pytest.mark.asyncio()
+@pytest.mark.usefixtures('all_jobs')
+async def test_stats_job_with_colon_in_the_name(redis: ArqRedis, queue: Queue) -> None:
+    job = await redis.enqueue_job('new_task', _job_id='queued:task')
+
+    assert await queue.get_stats() == QueueStats(
+        name=default_queue_name,
+        host=settings.REDIS_SETTINGS.host,
+        port=settings.REDIS_SETTINGS.port,
+        database=settings.REDIS_SETTINGS.database,
+        queued_jobs=2,
+        running_jobs=1,
+        deferred_jobs=1,
+    )
+
+
+@pytest.mark.asyncio()
 @patch.object(Queue, '_get_job_id_to_status_map')
 async def test_stats_with_error(mocked_get_job_ids: AsyncMock, queue: Queue) -> None:
     error_text = 'test error'


### PR DESCRIPTION
Splitting keys by colon gave unexpected results when jobs' names contain colon symbols. Use a regex instead 